### PR TITLE
Gracefully handle database errors

### DIFF
--- a/trades.php
+++ b/trades.php
@@ -13,43 +13,55 @@ if (!isset($data['action'])) {
     exit;
 }
 
-$pdo = get_db();
+try {
+    $pdo = get_db();
+} catch (Exception $e) {
+    debug_log('DB connection error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'error' => 'Database error. Please try again later.']);
+    exit;
+}
 
 if ($data['action'] === 'add') {
-    $pair_id = (int)($data['pair_id'] ?? 0);
-    $type = $data['type'];
-    $date = $data['date'];
+    try {
+        $pair_id = (int)($data['pair_id'] ?? 0);
+        $type = $data['type'];
+        $date = $data['date'];
 
-    // Validate pair_id
-    $stmt = $pdo->prepare("SELECT id FROM pairs WHERE id = ?");
-    $stmt->execute([$pair_id]);
-    if (!$stmt->fetchColumn()) {
-        debug_log("Invalid pair_id: $pair_id");
-        echo json_encode(['success' => false, 'error' => 'Invalid pair_id']);
+        // Validate pair_id
+        $stmt = $pdo->prepare("SELECT id FROM pairs WHERE id = ?");
+        $stmt->execute([$pair_id]);
+        if (!$stmt->fetchColumn()) {
+            debug_log("Invalid pair_id: $pair_id");
+            echo json_encode(['success' => false, 'error' => 'Invalid pair_id']);
+            exit;
+        }
+
+        if (!in_array($type, ['positive', 'negative'])) {
+            debug_log("Invalid type: $type");
+            echo json_encode(['success' => false, 'error' => 'Invalid type']);
+            exit;
+        }
+
+        // Insert trade
+        $stmt = $pdo->prepare("INSERT INTO trades (pair_id, date, type) VALUES (?, ?, ?)");
+        $stmt->execute([$pair_id, $date, $type]);
+        debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
+
+        // Return updated count for this type and pair in the last 14 days
+        $stmt2 = $pdo->prepare(
+            "SELECT COUNT(*) FROM trades WHERE pair_id = ? AND type = ? " .
+            "AND date BETWEEN DATE_SUB(?, INTERVAL 13 DAY) AND ?"
+        );
+        $stmt2->execute([$pair_id, $type, $date, $date]);
+        $count = $stmt2->fetchColumn();
+
+        echo json_encode(['success' => true, 'count' => $count]);
+        exit;
+    } catch (Exception $e) {
+        debug_log('Error processing trade: ' . $e->getMessage());
+        echo json_encode(['success' => false, 'error' => 'Database error. Please try again later.']);
         exit;
     }
-
-    if (!in_array($type, ['positive', 'negative'])) {
-        debug_log("Invalid type: $type");
-        echo json_encode(['success' => false, 'error' => 'Invalid type']);
-        exit;
-    }
-
-    // Insert trade
-    $stmt = $pdo->prepare("INSERT INTO trades (pair_id, date, type) VALUES (?, ?, ?)");
-    $stmt->execute([$pair_id, $date, $type]);
-    debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
-
-    // Return updated count for this type and pair in the last 14 days
-    $stmt2 = $pdo->prepare(
-        "SELECT COUNT(*) FROM trades WHERE pair_id = ? AND type = ? " .
-        "AND date BETWEEN DATE_SUB(?, INTERVAL 13 DAY) AND ?"
-    );
-    $stmt2->execute([$pair_id, $type, $date, $date]);
-    $count = $stmt2->fetchColumn();
-
-    echo json_encode(['success' => true, 'count' => $count]);
-    exit;
 }
 
 debug_log('Unknown action: ' . $data['action']);


### PR DESCRIPTION
## Summary
- wrap pair creation and stats queries in try/catch blocks and log failures
- guard trade API database calls with error handling and debug logging
- show a friendly error message on the front page when a database error occurs

## Testing
- `php -l index.php`
- `php -l trades.php`


------
https://chatgpt.com/codex/tasks/task_e_68b11f648cbc8326b9e098de24871903