### PR TITLE
Fix redirect URL query handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['new_pair'])) {
             $stmt = $pdo->prepare("INSERT IGNORE INTO pairs (name) VALUES (?)");
             $stmt->execute([$new_pair]);
             // Redirect to avoid resubmission only on success
-            header("Location: " . strtok($_SERVER['REQUEST_URI'], '?') . '?' . http_build_query($_GET));
+            header("Location: " . strtok($_SERVER['REQUEST_URI'], '?') . (!empty($_GET) ? '?' . http_build_query($_GET) : ''));
             exit;
         } catch (Exception $e) {
             debug_log('Error adding pair: ' . $e->getMessage());


### PR DESCRIPTION
## Summary
- Avoid adding a `?` to redirect URL when there are no query parameters

## Testing
- `curl -L -i -X POST -d "new_pair=ETHUSD" http://127.0.0.1:8000/index.php`
- `curl -L -i -X POST -d "new_pair=XRPUSD" "http://127.0.0.1:8000/index.php?date=2024-06-21"`


------
https://chatgpt.com/codex/tasks/task_e_68b1272b1ca88326b77ccee59d09afb0