### PR TITLE
Check file write result in debug log

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -10,5 +10,24 @@ function debug_log($message): void {
     if (is_array($message) || is_object($message)) {
         $message = print_r($message, true);
     }
-    file_put_contents($logFile, "[$timestamp] $message\n", FILE_APPEND);
+
+    // Attempt to create the log file if it does not exist and we have permission
+    if (!file_exists($logFile)) {
+        $dir = dirname($logFile);
+        if (is_writable($dir)) {
+            if (@touch($logFile) === false) {
+                error_log("debug_log: Failed to create log file at $logFile");
+                return;
+            }
+        } else {
+            error_log("debug_log: Directory not writable for log file at $dir");
+            return;
+        }
+    }
+
+    // Write log entry and check for failure
+    $bytesWritten = @file_put_contents($logFile, "[$timestamp] $message\n", FILE_APPEND);
+    if ($bytesWritten === false) {
+        error_log("debug_log: Failed to write to log file at $logFile");
+    }
 }


### PR DESCRIPTION
## Summary
- Guard against failures when writing debug logs
- Attempt to create debug.log if missing and directory writable
- Surface logging issues via `error_log`

## Testing
- `php -l debug.php`


------
https://chatgpt.com/codex/tasks/task_e_68b13368a140832692a0ddf277f31eed