### PR TITLE
Add server-side CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight PHP-based backend for recording and reporting trades with positive
 - **Add Trades:** Record trades for specific pairs with type (`positive` or `negative`) and date.
 - **14-Day Reporting:** Get the count of positive or negative trades per pair for the last 14 days.
 - **RESTful API:** Simple POST-based API for integration.
+- **CSRF Protection:** All POST requests require a valid CSRF token stored in the user session.
 
 ## Files
 
@@ -27,7 +28,8 @@ A lightweight PHP-based backend for recording and reporting trades with positive
   "action": "add",
   "pair_id": 1,
   "type": "positive",
-  "date": "2025-08-29"
+  "date": "2025-08-29",
+  "csrf_token": "<token from session>"
 }
 ```
 
@@ -49,6 +51,10 @@ Error responses will include `success: false` and an error message:
   "error": "Invalid pair_id"
 }
 ```
+
+## CSRF Tokens
+
+Every POST request must include a `csrf_token` value that matches the token stored in the current session. The main page embeds this token in the "Add Pair" form and exposes it to JavaScript for API calls.
 
 ## Database Setup
 

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,19 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+function get_csrf_token(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validate_csrf_token(?string $token): bool {
+    $session_token = $_SESSION['csrf_token'] ?? '';
+    if (!is_string($token) || $session_token === '') {
+        return false;
+    }
+    return hash_equals($session_token, $token);
+}

--- a/tests/csrf_token_test.php
+++ b/tests/csrf_token_test.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../csrf.php';
+
+$token = get_csrf_token();
+if (!validate_csrf_token($token)) {
+    echo "Token validation failed for valid token\n";
+    exit(1);
+}
+
+if (validate_csrf_token('invalid')) {
+    echo "Token validation succeeded for invalid token\n";
+    exit(1);
+}
+
+echo "CSRF token tests passed\n";

--- a/trades.php
+++ b/trades.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'db.php';
 require_once 'debug.php';
+require_once 'csrf.php';
 
 header('Content-Type: application/json');
 
@@ -10,6 +11,12 @@ debug_log(['request' => $data]);
 if (!isset($data['action'])) {
     debug_log('No action specified');
     echo json_encode(['success' => false, 'error' => 'No action specified']);
+    exit;
+}
+
+if (!validate_csrf_token($data['csrf_token'] ?? '')) {
+    debug_log('Invalid CSRF token');
+    echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Generate and validate CSRF tokens with new helper
- Protect add pair form and trade API by checking token
- Document CSRF usage and add token test

## Testing
- `php -l index.php trades.php csrf.php tests/csrf_token_test.php`
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b134095f308326ad48ef7237219f53