### PR TITLE
Use environment variables for DB configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_NAME=algos1score
+DB_USER=algos1score_user
+DB_PASS=algos1score_password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.debug.log
+debug.log

--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ CREATE TABLE IF NOT EXISTS trades (
 
 ## Configuration
 
-Update `config.php` with your database credentials:
-```php
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'algos1score');
-define('DB_USER', 'your_db_user');
-define('DB_PASS', 'your_db_password');
+Database credentials are read from environment variables. Set the following values in your environment or in a `.env` file:
+
+```bash
+DB_HOST=localhost
+DB_NAME=algos1score
+DB_USER=your_db_user
+DB_PASS=your_db_password
 ```
+
+If you're using [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv), copy `.env.example` to `.env` and adjust the values as needed.
 
 ## Debug Logging
 

--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
 // Database configuration
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'algos1score');
-define('DB_USER', 'algos1score_user');
-define('DB_PASS', 'algos1score_password');
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_NAME', getenv('DB_NAME') ?: 'algos1score');
+define('DB_USER', getenv('DB_USER') ?: 'algos1score_user');
+define('DB_PASS', getenv('DB_PASS') ?: 'algos1score_password');


### PR DESCRIPTION
## Summary
- Replace hard-coded DB credentials in `config.php` with `getenv` lookups
- Document environment variable setup and add `.env.example`
- Ignore local `.env` files in version control

## Testing
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1351a5560832682e2b14b81ef8ce1