### PR TITLE
Add unique index for trades and handle duplicates

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS trades (
     date DATE NOT NULL,
     type ENUM('positive', 'negative') NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (pair_id) REFERENCES pairs(id) ON DELETE CASCADE
+    FOREIGN KEY (pair_id) REFERENCES pairs(id) ON DELETE CASCADE,
+    UNIQUE KEY uniq_pair_date_type (pair_id, date, type)
 );

--- a/trades.php
+++ b/trades.php
@@ -51,8 +51,17 @@ if ($data['action'] === 'add') {
 
         // Insert trade
         $stmt = $pdo->prepare("INSERT INTO trades (pair_id, date, type) VALUES (?, ?, ?)");
-        $stmt->execute([$pair_id, $date, $type]);
-        debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
+        try {
+            $stmt->execute([$pair_id, $date, $type]);
+            debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
+        } catch (PDOException $e) {
+            if ($e->getCode() === '23000') { // Unique constraint violation
+                debug_log("Duplicate trade pair_id=$pair_id type=$type date=$date");
+                echo json_encode(['success' => false, 'error' => 'Trade already exists for this pair, date, and type']);
+                exit;
+            }
+            throw $e;
+        }
 
         // Return updated count for this type and pair in the last 14 days
         $stmt2 = $pdo->prepare(


### PR DESCRIPTION
## Summary
- ensure uniqueness of (pair_id, date, type) in trades table
- catch duplicate trade insertions and return informative error

## Testing
- `php -l trades.php`
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b137d03db8832686ae53ba82d2d7d3