### PR TITLE
Namespace debug logger and introduce autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ If you're using [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv), copy `.
 
 ## Debug Logging
 
-`debug.php` provides a `debug_log()` helper that writes messages to `debug.log` in the project root. Each entry in the log includes a timestamp.
+The `App\Debug\debug_log()` helper writes messages to `debug.log` in the project root. Each entry includes a timestamp.
 
 To record a message:
 
 ```php
-require 'debug.php';
+require 'autoload.php';
+
+use function App\Debug\debug_log;
+
 debug_log('Something happened');
 ```
 

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Minimal PSR-4 autoloader for the App namespace.
+ */
+spl_autoload_register(function ($class) {
+    $prefix = 'App\\';
+    $base_dir = __DIR__ . '/src/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative_class = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+// Include namespaced function libraries
+require_once __DIR__ . '/src/Debug/debug.php';

--- a/db.php
+++ b/db.php
@@ -1,6 +1,8 @@
 <?php
 require_once __DIR__ . '/config.php';
-require_once __DIR__ . '/debug.php';
+require_once __DIR__ . '/autoload.php';
+
+use function App\Debug\debug_log;
 
 function get_db() {
     static $pdo;

--- a/index.php
+++ b/index.php
@@ -2,6 +2,8 @@
 require_once 'db.php';
 require_once 'csrf.php';
 
+use function App\Debug\debug_log;
+
 $error_message = null;
 $csrf_token = get_csrf_token();
 

--- a/src/Debug/debug.php
+++ b/src/Debug/debug.php
@@ -1,11 +1,14 @@
 <?php
+
+namespace App\Debug;
+
 /**
  * Simple file-based debug logger.
  *
  * Writes messages to debug.log in the project root with a timestamp.
  */
 function debug_log($message): void {
-    $logFile = __DIR__ . '/debug.log';
+    $logFile = dirname(__DIR__, 2) . '/debug.log';
     $timestamp = date('Y-m-d H:i:s');
     if (is_array($message) || is_object($message)) {
         $message = print_r($message, true);

--- a/trades.php
+++ b/trades.php
@@ -1,7 +1,9 @@
 <?php
-require_once 'db.php';
-require_once 'debug.php';
-require_once 'csrf.php';
+require_once __DIR__ . '/autoload.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/csrf.php';
+
+use function App\Debug\debug_log;
 
 header('Content-Type: application/json');
 


### PR DESCRIPTION
## Summary
- Move debug_log helper under App\Debug namespace
- Add minimal PSR-4 autoloader and load debug helper
- Update db.php, trades.php, and docs to reference namespaced logger

## Testing
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b138ab901c832685eb1b98cd8570d2