### PR TITLE
refactor: move trade event handler to external script

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const csrfInput = document.querySelector('#addPairForm input[name="csrf_token"]');
+    const csrfToken = csrfInput ? csrfInput.value : '';
+
+    document.querySelectorAll('button.plus, button.minus').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            const tr = btn.closest('tr');
+            const pair_id = tr.getAttribute('data-pair-id');
+            const type = btn.getAttribute('data-type');
+            const date = document.getElementById('date').value;
+            fetch('trades.php', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ action: 'add', pair_id, type, date, csrf_token: csrfToken })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    tr.querySelector('.' + type).textContent = data.count;
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            })
+            .catch(err => {
+                console.error('Fetch error:', err);
+                alert('An error occurred while communicating with the server. Please try again later.');
+            });
+        });
+    });
+});

--- a/index.php
+++ b/index.php
@@ -130,34 +130,6 @@ if ($pair_ids) {
             <?php endforeach ?>
         </tbody>
     </table>
-    <script>
-        const csrfToken = '<?= $csrf_token ?>';
-        document.querySelectorAll('button.plus, button.minus').forEach(function(btn){
-            btn.addEventListener('click', function(e){
-                e.preventDefault();
-                let tr = btn.closest('tr');
-                let pair_id = tr.getAttribute('data-pair-id');
-                let type = btn.getAttribute('data-type');
-                let date = document.getElementById('date').value;
-                fetch('trades.php', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({ action: 'add', pair_id, type, date, csrf_token: csrfToken })
-                })
-                .then(r => r.json())
-                .then(data => {
-                    if (data.success) {
-                        tr.querySelector('.' + type).textContent = data.count;
-                    } else {
-                        alert('Error: ' + data.error);
-                    }
-                })
-                .catch(err => {
-                    console.error('Fetch error:', err);
-                    alert('An error occurred while communicating with the server. Please try again later.');
-                });
-            });
-        });
-    </script>
+    <script src="assets/js/trades.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move inline trade button logic into `assets/js/trades.js`
- link external `trades.js` from `index.php`
- ensure handlers run after DOMContentLoaded

## Testing
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b13bac100483269b8b0f7c83cd8883