### PR TITLE
Add database connection closing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A lightweight PHP-based backend for recording and reporting trades with positive
 ## Files
 
 - `config.php` – Database connection configuration.
-- `db.php` – PDO-based database connection handler.
+- `db.php` – PDO-based database connection handler. Use `get_db()` for a
+  connection and `close_db()` to release it when you're done.
 - `trades.php` – Main endpoint for adding trades and reporting.
   
 ## API Usage
@@ -88,6 +89,18 @@ DB_PASS=your_db_password
 ```
 
 If you're using [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv), copy `.env.example` to `.env` and adjust the values as needed.
+
+## Closing the Database Connection
+
+Use `close_db()` when your script is finished with the database or after
+long-running tasks to explicitly release the PDO connection. A subsequent call
+to `get_db()` will create a new connection if needed.
+
+```php
+$pdo = get_db();
+// ... work with the database ...
+close_db(); // typically at script shutdown or after a long-running job
+```
 
 ## Debug Logging
 

--- a/db.php
+++ b/db.php
@@ -4,8 +4,24 @@ require_once __DIR__ . '/autoload.php';
 
 use function App\Debug\debug_log;
 
+/**
+ * Returns a reference to the static PDO instance used by the application.
+ *
+ * @return \PDO|null Reference to the PDO instance or null if not connected.
+ */
+function &pdo_instance() {
+    static $pdo = null;
+    return $pdo;
+}
+
+/**
+ * Get (and lazily create) the application's PDO connection.
+ *
+ * @return \PDO Active PDO connection.
+ * @throws \PDOException When the connection cannot be established.
+ */
 function get_db() {
-    static $pdo;
+    $pdo = &pdo_instance();
     if (!$pdo) {
         $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
         try {
@@ -19,4 +35,17 @@ function get_db() {
         }
     }
     return $pdo;
+}
+
+/**
+ * Close the database connection.
+ *
+ * Calling this function sets the internal PDO instance to null so a
+ * subsequent call to {@see get_db()} will create a new connection. Use this
+ * at the end of scripts or after long-running tasks to free up resources.
+ */
+function close_db() {
+    $pdo = &pdo_instance();
+    $pdo = null;
+    debug_log('Database connection closed');
 }


### PR DESCRIPTION
## Summary
- add `close_db()` to clear the static PDO instance and log closure
- document when to call `close_db()` and how to release connections

## Testing
- `php -l db.php`
- `php tests/csrf_token_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b13df5ba0c8326b6d0243b32c6abb8