### PR TITLE
feat: add asynchronous debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ close_db(); // typically at script shutdown or after a long-running job
 
 ## Debug Logging
 
-The `App\Debug\debug_log()` helper writes messages to `debug.log` in the project root. Each entry includes a timestamp.
+The `App\Debug\debug_log()` helper collects messages in memory and writes them
+to `debug.log` at script shutdown. Each entry includes a timestamp. Messages are
+also forwarded to the system logger (syslog) immediately when available.
 
 To record a message:
 
@@ -116,7 +118,7 @@ use function App\Debug\debug_log;
 debug_log('Something happened');
 ```
 
-To watch log output in real time:
+To watch buffered log output in real time:
 
 ```bash
 tail -f debug.log
@@ -128,7 +130,16 @@ Each log entry looks like:
 [2025-08-30 12:34:56] Something happened
 ```
 
-Use these timestamps and messages to trace application flow and troubleshoot issues.
+### Performance Trade-offs
+
+Buffered logging reduces the number of file writes, which can improve
+performance on busy systems. Forwarding to syslog allows the operating system to
+handle log persistence asynchronously. However, messages may not appear in
+`debug.log` until the script exits, and they could be lost if the process ends
+abruptly or if the system logger is unavailable.
+
+Use these timestamps and messages to trace application flow and troubleshoot
+issues.
 
 ## License
 

--- a/src/Debug/debug.php
+++ b/src/Debug/debug.php
@@ -3,34 +3,61 @@
 namespace App\Debug;
 
 /**
- * Simple file-based debug logger.
+ * Buffered debug logger with optional syslog forwarding.
  *
- * Writes messages to debug.log in the project root with a timestamp.
+ * Messages are queued in memory and flushed to debug.log at script shutdown
+ * to reduce I/O overhead. Each message is also sent to the system logger
+ * (syslog) immediately when available.
  */
 function debug_log($message): void {
-    $logFile = dirname(__DIR__, 2) . '/debug.log';
+    static $buffer = [];
+    static $registered = false;
+    static $syslogOpened = false;
+
     $timestamp = date('Y-m-d H:i:s');
     if (is_array($message) || is_object($message)) {
         $message = print_r($message, true);
     }
+    $line = "[$timestamp] $message";
 
-    // Attempt to create the log file if it does not exist and we have permission
-    if (!file_exists($logFile)) {
-        $dir = dirname($logFile);
-        if (is_writable($dir)) {
-            if (@touch($logFile) === false) {
-                error_log("debug_log: Failed to create log file at $logFile");
-                return;
-            }
-        } else {
-            error_log("debug_log: Directory not writable for log file at $dir");
-            return;
+    // Forward to syslog for asynchronous handling if available
+    if (function_exists('openlog') && function_exists('syslog')) {
+        if (!$syslogOpened) {
+            openlog('algos1score', LOG_PID, LOG_USER);
+            $syslogOpened = true;
         }
+        syslog(LOG_INFO, $line);
     }
 
-    // Write log entry and check for failure
-    $bytesWritten = @file_put_contents($logFile, "[$timestamp] $message\n", FILE_APPEND);
-    if ($bytesWritten === false) {
-        error_log("debug_log: Failed to write to log file at $logFile");
+    // Queue the line for buffered file writing
+    $buffer[] = $line;
+
+    if (!$registered) {
+        $registered = true;
+        register_shutdown_function(function () use (&$buffer) {
+            if (!$buffer) {
+                return;
+            }
+            $logFile = dirname(__DIR__, 2) . '/debug.log';
+            $dir = dirname($logFile);
+
+            if (!file_exists($logFile) && !is_writable($dir)) {
+                error_log("debug_log: Directory not writable for log file at $dir");
+                return;
+            }
+
+            if (!file_exists($logFile)) {
+                if (@touch($logFile) === false) {
+                    error_log("debug_log: Failed to create log file at $logFile");
+                    return;
+                }
+            }
+
+            $data = implode(PHP_EOL, $buffer) . PHP_EOL;
+            $bytesWritten = @file_put_contents($logFile, $data, FILE_APPEND);
+            if ($bytesWritten === false) {
+                error_log("debug_log: Failed to write to log file at $logFile");
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- buffer debug log messages and forward them to syslog asynchronously
- document logging behavior and performance trade-offs in README

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1404149cc832689b89394b37178b8