### PR TITLE
Allow multiple trades per pair on same date

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,5 @@ CREATE TABLE IF NOT EXISTS trades (
     date DATE NOT NULL,
     type ENUM('positive', 'negative') NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (pair_id) REFERENCES pairs(id) ON DELETE CASCADE,
-    UNIQUE KEY uniq_pair_date_type (pair_id, date, type)
+    FOREIGN KEY (pair_id) REFERENCES pairs(id) ON DELETE CASCADE
 );

--- a/tests/TradesApiTest.php
+++ b/tests/TradesApiTest.php
@@ -17,7 +17,7 @@ class TradesApiTest extends TestCase
 
         $this->pdo = get_db();
         $this->pdo->exec('CREATE TABLE pairs (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL)');
-        $this->pdo->exec("CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, pair_id INTEGER NOT NULL, date TEXT NOT NULL, type TEXT NOT NULL, created_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(pair_id) REFERENCES pairs(id) ON DELETE CASCADE, UNIQUE(pair_id, date, type))");
+        $this->pdo->exec("CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, pair_id INTEGER NOT NULL, date TEXT NOT NULL, type TEXT NOT NULL, created_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(pair_id) REFERENCES pairs(id) ON DELETE CASCADE)");
         $this->pdo->exec("INSERT INTO pairs (name) VALUES ('BTCUSD')");
         $this->csrfToken = get_csrf_token();
     }
@@ -43,7 +43,7 @@ class TradesApiTest extends TestCase
         $this->assertSame('Invalid CSRF token', $response['error']);
     }
 
-    public function testAddTradeAndDuplicate(): void
+    public function testAddTradeAllowsDuplicates(): void
     {
         $payload = [
             'action' => 'add',
@@ -57,7 +57,7 @@ class TradesApiTest extends TestCase
         $this->assertSame(1, $response['count']);
 
         $duplicate = handle_trades($payload);
-        $this->assertFalse($duplicate['success']);
-        $this->assertSame('Trade already exists for this pair, date, and type', $duplicate['error']);
+        $this->assertTrue($duplicate['success']);
+        $this->assertSame(2, $duplicate['count']);
     }
 }

--- a/trades.php
+++ b/trades.php
@@ -52,16 +52,8 @@ function handle_trades(?array $data): array {
 
             // Insert trade
             $stmt = $pdo->prepare("INSERT INTO trades (pair_id, date, type) VALUES (?, ?, ?)");
-            try {
-                $stmt->execute([$pair_id, $date, $type]);
-                debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
-            } catch (PDOException $e) {
-                if ($e->getCode() === '23000') { // Unique constraint violation
-                    debug_log("Duplicate trade pair_id=$pair_id type=$type date=$date");
-                    return ['success' => false, 'error' => 'Trade already exists for this pair, date, and type'];
-                }
-                throw $e;
-            }
+            $stmt->execute([$pair_id, $date, $type]);
+            debug_log("Inserted trade pair_id=$pair_id type=$type date=$date");
 
             // Return updated count for this type and pair in the last 14 days
             $driver = DB_DSN ? explode(':', DB_DSN, 2)[0] : 'mysql';


### PR DESCRIPTION
## Summary
- remove unique constraint on `trades` to allow multiple trades for a pair and date
- simplify trade insert logic and allow duplicates
- update tests for duplicate trades

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b14b9fae088326b111571f83867f43