### PR TITLE
Show trade list drawer for each pair

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -28,4 +28,48 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
+
+    document.querySelectorAll('td.pair-name').forEach(td => {
+        td.addEventListener('click', () => {
+            const tr = td.parentElement;
+            const drawer = tr.nextElementSibling;
+            const pair_id = tr.getAttribute('data-pair-id');
+            const date = document.getElementById('date').value;
+
+            if (drawer.style.display === 'table-row') {
+                drawer.style.display = 'none';
+                return;
+            }
+
+            if (!drawer.dataset.loaded) {
+                fetch('trades.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'list', pair_id, date, csrf_token: csrfToken })
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        const ul = document.createElement('ul');
+                        data.trades.forEach(t => {
+                            const li = document.createElement('li');
+                            li.textContent = `${t.date} - ${t.type}`;
+                            ul.appendChild(li);
+                        });
+                        drawer.querySelector('.trades-cell').appendChild(ul);
+                        drawer.dataset.loaded = 'true';
+                    } else {
+                        alert('Error: ' + data.error);
+                    }
+                    drawer.style.display = 'table-row';
+                })
+                .catch(err => {
+                    console.error('Fetch error:', err);
+                    alert('An error occurred while communicating with the server. Please try again later.');
+                });
+            } else {
+                drawer.style.display = 'table-row';
+            }
+        });
+    });
 });

--- a/index.php
+++ b/index.php
@@ -104,6 +104,8 @@ if ($pair_ids) {
         button.plus { color: #fff; background: #4caf50; border: none; padding: 0.3em 1em; cursor: pointer; }
         button.minus { color: #fff; background: #f44336; border: none; padding: 0.3em 1em; cursor: pointer; }
         form.inline { display: inline; }
+        td.pair-name { cursor: pointer; color: #1a0dab; text-decoration: underline; }
+        tr.drawer { display: none; background: #f9f9f9; }
     </style>
 </head>
 <body>
@@ -133,19 +135,22 @@ if ($pair_ids) {
             </tr>
         </thead>
         <tbody id="pairsTable">
-            <?php foreach ($pairs as $pair): 
+            <?php foreach ($pairs as $pair):
                 $pid = $pair['id'];
                 $pos = $stats[$pid]['positive'] ?? 0;
                 $neg = $stats[$pid]['negative'] ?? 0;
             ?>
-            <tr data-pair-id="<?= (int)$pid ?>">
-                <td><?= htmlspecialchars(strtoupper($pair['name'])) ?></td>
+            <tr data-pair-id="<?= (int)$pid ?>" class="pair-row">
+                <td class="pair-name"><?= htmlspecialchars(strtoupper($pair['name'])) ?></td>
                 <td class="positive"><?= $pos ?></td>
                 <td class="negative"><?= $neg ?></td>
                 <td>
                     <button class="plus" data-type="positive">+</button>
                     <button class="minus" data-type="negative">-</button>
                 </td>
+            </tr>
+            <tr class="drawer">
+                <td colspan="4" class="trades-cell"></td>
             </tr>
             <?php endforeach ?>
         </tbody>

--- a/tests/TradesApiTest.php
+++ b/tests/TradesApiTest.php
@@ -60,4 +60,31 @@ class TradesApiTest extends TestCase
         $this->assertTrue($duplicate['success']);
         $this->assertSame(2, $duplicate['count']);
     }
+
+    public function testListTrades(): void
+    {
+        $payload = [
+            'action' => 'add',
+            'pair_id' => 1,
+            'type' => 'positive',
+            'date' => '2024-01-01',
+            'csrf_token' => $this->csrfToken,
+        ];
+        handle_trades($payload);
+        $payload['type'] = 'negative';
+        handle_trades($payload);
+
+        $list = handle_trades([
+            'action' => 'list',
+            'pair_id' => 1,
+            'date' => '2024-01-01',
+            'csrf_token' => $this->csrfToken,
+        ]);
+
+        $this->assertTrue($list['success']);
+        $this->assertCount(2, $list['trades']);
+        $types = array_column($list['trades'], 'type');
+        $this->assertContains('positive', $types);
+        $this->assertContains('negative', $types);
+    }
 }


### PR DESCRIPTION
## Summary
- allow clicking on pair names to toggle a drawer showing the trades contributing to its score
- add `list` action to trade API to return recent trades
- cover trade listing with PHPUnit tests

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b152f62d1c832682f8067d32a80fee