### PR TITLE
Add trades view button for each pair

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -29,9 +29,9 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    document.querySelectorAll('td.pair-name').forEach(td => {
-        td.addEventListener('click', () => {
-            const tr = td.parentElement;
+    document.querySelectorAll('button.view-trades').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const tr = btn.closest('tr');
             const drawer = tr.nextElementSibling;
             const cell = drawer.querySelector('.trades-cell');
             const pair_id = tr.getAttribute('data-pair-id');
@@ -41,7 +41,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 drawer.style.display = 'none';
                 return;
             }
-
 
             drawer.style.display = 'table-row';
 

--- a/index.php
+++ b/index.php
@@ -104,7 +104,6 @@ if ($pair_ids) {
         button.plus { color: #fff; background: #4caf50; border: none; padding: 0.3em 1em; cursor: pointer; }
         button.minus { color: #fff; background: #f44336; border: none; padding: 0.3em 1em; cursor: pointer; }
         form.inline { display: inline; }
-        td.pair-name { cursor: pointer; color: #1a0dab; text-decoration: underline; }
         tr.drawer { display: none; background: #f9f9f9; }
     </style>
 </head>
@@ -147,6 +146,7 @@ if ($pair_ids) {
                 <td>
                     <button class="plus" data-type="positive">+</button>
                     <button class="minus" data-type="negative">-</button>
+                    <button class="view-trades">Trades</button>
                 </td>
             </tr>
             <tr class="drawer">

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -41,6 +41,7 @@ class IndexPageTest extends TestCase
         $this->assertMatchesRegularExpression('/<td class="positive">\s*2\s*<\/td>/', $output);
         $this->assertMatchesRegularExpression('/<td class="negative">\s*1\s*<\/td>/', $output);
         $this->assertStringContainsString('name="csrf_token" value="'.htmlspecialchars($token, ENT_QUOTES).'"', $output);
+        $this->assertStringContainsString('<button class="view-trades">', $output);
     }
 
     public function testAddingPairCapitalizesName(): void


### PR DESCRIPTION
## Summary
- Replace clickable pair names with plain text and add a "Trades" button in each row
- Update JavaScript to load and toggle trades from the new button
- Extend index page test to assert presence of the new trades button

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1583041908326b86a4fe650136c1c