### PR TITLE
Ensure trades fetch includes credentials

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
             fetch('trades.php', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({ action: 'add', pair_id, type, date, csrf_token: csrfToken })
+                body: JSON.stringify({ action: 'add', pair_id, type, date, csrf_token: csrfToken }),
+                credentials: 'same-origin'
             })
             .then(r => r.json())
             .then(data => {
@@ -50,7 +51,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 fetch('trades.php', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'list', pair_id, date, csrf_token: csrfToken })
+                    body: JSON.stringify({ action: 'list', pair_id, date, csrf_token: csrfToken }),
+                    credentials: 'same-origin'
                 })
                 .then(r => r.json())
                 .then(data => {


### PR DESCRIPTION
## Summary
- send cookies alongside CSRF token by adding `credentials: 'same-origin'` to trades API calls

## Testing
- ⚠️ `composer test` *(failed: Script phpunit handling the test event returned with error code 1)*
- ✅ `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed707830832690c7db8a5caec5a2