### PR TITLE
Handle malformed trade request bodies

### DIFF
--- a/tests/TradesApiTest.php
+++ b/tests/TradesApiTest.php
@@ -29,11 +29,15 @@ class TradesApiTest extends TestCase
         session_destroy();
     }
 
-    public function testMissingAction(): void
+    public function testMissingOrMalformedBody(): void
     {
+        $response = handle_trades(null);
+        $this->assertFalse($response['success']);
+        $this->assertSame('Malformed or missing request body', $response['error']);
+
         $response = handle_trades(['csrf_token' => $this->csrfToken]);
         $this->assertFalse($response['success']);
-        $this->assertSame('No action specified', $response['error']);
+        $this->assertSame('Malformed or missing request body', $response['error']);
     }
 
     public function testInvalidCsrfToken(): void

--- a/trades.php
+++ b/trades.php
@@ -14,9 +14,9 @@ use function App\Debug\debug_log;
 function handle_trades(?array $data): array {
     debug_log(['request' => $data]);
 
-    if (!isset($data['action'])) {
-        debug_log('No action specified');
-        return ['success' => false, 'error' => 'No action specified'];
+    if (!is_array($data) || !isset($data['action'])) {
+        debug_log('Malformed or missing request body');
+        return ['success' => false, 'error' => 'Malformed or missing request body'];
     }
 
     if (!validate_csrf_token($data['csrf_token'] ?? '')) {


### PR DESCRIPTION
## Summary
- Harden trade handler against missing or malformed request bodies
- Test trade handler rejects malformed request data

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1ee8d5df4832683a2315f3f36a93d