### PR TITLE
Prevent default view trade behaviour

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -31,7 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.querySelectorAll('button.view-trades').forEach(btn => {
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
             const tr = btn.closest('tr');
             const drawer = tr.nextElementSibling;
             const cell = drawer.querySelector('.trades-cell');


### PR DESCRIPTION
## Summary
- prevent default action on view trades button before toggling drawer

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef96672883269db0f3b4b124f732