### PR TITLE
Display trades on dedicated page

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -36,62 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const tr = btn.closest('tr');
             const pair_id = tr.getAttribute('data-pair-id');
             const date = document.getElementById('date').value;
-
-            const tradeRows = [];
-            let next = tr.nextElementSibling;
-            while (next && next.classList.contains('trade-row')) {
-                tradeRows.push(next);
-                next = next.nextElementSibling;
-            }
-
-            if (tradeRows.length > 0) {
-                const hidden = tradeRows[0].style.display === 'none';
-                tradeRows.forEach(row => {
-                    row.style.display = hidden ? 'table-row' : 'none';
-                });
-                return;
-            }
-
-            fetch('trades.php', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'list', pair_id, date, csrf_token: csrfToken }),
-                credentials: 'same-origin'
-            })
-            .then(r => r.json())
-            .then(data => {
-                if (data.success) {
-                    const tbody = tr.parentNode;
-                    const insertBefore = tr.nextSibling;
-                    if (data.trades.length === 0) {
-                        const row = document.createElement('tr');
-                        row.className = 'trade-row';
-                        const cell = document.createElement('td');
-                        cell.colSpan = 4;
-                        cell.textContent = 'No trades in this period.';
-                        row.appendChild(cell);
-                        tbody.insertBefore(row, insertBefore);
-                        row.style.display = 'table-row';
-                    } else {
-                        data.trades.forEach(t => {
-                            const row = document.createElement('tr');
-                            row.className = 'trade-row';
-                            const cell = document.createElement('td');
-                            cell.colSpan = 4;
-                            cell.textContent = `${t.date} - ${t.type}`;
-                            row.appendChild(cell);
-                            tbody.insertBefore(row, insertBefore);
-                            row.style.display = 'table-row';
-                        });
-                    }
-                } else {
-                    alert('Error: ' + data.error);
-                }
-            })
-            .catch(err => {
-                console.error('Fetch error:', err);
-                alert('An error occurred while communicating with the server. Please try again later.');
-            });
+            window.location.href = `trades_view.php?pair_id=${encodeURIComponent(pair_id)}&date=${encodeURIComponent(date)}`;
         });
     });
 });

--- a/index.php
+++ b/index.php
@@ -104,7 +104,6 @@ if ($pair_ids) {
         button.plus { color: #fff; background: #4caf50; border: none; padding: 0.3em 1em; cursor: pointer; }
         button.minus { color: #fff; background: #f44336; border: none; padding: 0.3em 1em; cursor: pointer; }
         form.inline { display: inline; }
-        tr.trade-row { display: none; background: #f9f9f9; }
     </style>
 </head>
 <body>

--- a/trades_view.php
+++ b/trades_view.php
@@ -1,0 +1,79 @@
+<?php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/csrf.php';
+
+use function App\Debug\debug_log;
+
+$error_message = null;
+$pair_name = '';
+$pair_id = isset($_GET['pair_id']) ? (int)$_GET['pair_id'] : 0;
+$date = $_GET['date'] ?? date('Y-m-d');
+
+try {
+    $pdo = get_db();
+    $stmt = $pdo->prepare('SELECT name FROM pairs WHERE id = ?');
+    $stmt->execute([$pair_id]);
+    $pair_name = $stmt->fetchColumn();
+    if (!$pair_name) {
+        $error_message = 'Invalid pair ID.';
+    }
+} catch (Exception $e) {
+    debug_log('Error fetching pair: ' . $e->getMessage());
+    $error_message = 'An error occurred while retrieving data. Please try again later.';
+}
+
+$trades = [];
+if (!$error_message) {
+    try {
+        $driver = DB_DSN ? explode(':', DB_DSN, 2)[0] : 'mysql';
+        if ($driver === 'sqlite') {
+            $sql = "SELECT date, type FROM trades WHERE pair_id = ? " .
+                "AND date BETWEEN date(?, '-13 day') AND ? ORDER BY date DESC, id DESC";
+        } else {
+            $sql = "SELECT date, type FROM trades WHERE pair_id = ? " .
+                "AND date BETWEEN DATE_SUB(?, INTERVAL 13 DAY) AND ? ORDER BY date DESC, id DESC";
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([$pair_id, $date, $date]);
+        $trades = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } catch (Exception $e) {
+        debug_log('Error fetching trades: ' . $e->getMessage());
+        $error_message = 'Could not retrieve trades.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Trades</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { padding: 0.5em 1em; border: 1px solid #ccc; }
+    </style>
+</head>
+<body>
+    <h2>Trades for <?= htmlspecialchars(strtoupper($pair_name)) ?> - Last 14 Days</h2>
+    <?php if ($error_message): ?>
+        <p style="color:red;"><?= htmlspecialchars($error_message) ?></p>
+    <?php elseif (empty($trades)): ?>
+        <p>No trades in this period.</p>
+    <?php else: ?>
+        <table>
+            <thead>
+                <tr><th>Date</th><th>Type</th></tr>
+            </thead>
+            <tbody>
+                <?php foreach ($trades as $t): ?>
+                <tr>
+                    <td><?= htmlspecialchars($t['date']) ?></td>
+                    <td><?= htmlspecialchars($t['type']) ?></td>
+                </tr>
+                <?php endforeach ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+    <p><a href="index.php?date=<?= htmlspecialchars($date) ?>">Back to main page</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Remove inline hidden rows from main stats table
- Redirect "Trades" button to new page showing trade history
- Add standalone trade listing page with link back to main view

## Testing
- `./vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68b1f3734010832685ef6c4d1f33ff82