### PR TITLE
Add link to trades view

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -30,13 +30,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    document.querySelectorAll('button.view-trades').forEach(btn => {
-        btn.addEventListener('click', e => {
-            e.preventDefault();
-            const tr = btn.closest('tr');
+    document.querySelectorAll('a.view-trades').forEach(link => {
+        link.addEventListener('click', e => {
+            const tr = link.closest('tr');
             const pair_id = tr.getAttribute('data-pair-id');
             const date = document.getElementById('date').value;
-            window.location.href = `trades_view.php?pair_id=${encodeURIComponent(pair_id)}&date=${encodeURIComponent(date)}`;
+            link.href = `trades_view.php?pair_id=${encodeURIComponent(pair_id)}&date=${encodeURIComponent(date)}`;
         });
     });
 });

--- a/index.php
+++ b/index.php
@@ -145,7 +145,7 @@ if ($pair_ids) {
                 <td>
                     <button class="plus" data-type="positive">+</button>
                     <button class="minus" data-type="negative">-</button>
-                    <button class="view-trades">Trades</button>
+                    <a class="view-trades" href="<?= htmlspecialchars('trades_view.php?pair_id=' . (int)$pid . '&date=' . $selected_date) ?>">Trades</a>
                 </td>
             </tr>
             <?php endforeach ?>

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -41,7 +41,7 @@ class IndexPageTest extends TestCase
         $this->assertMatchesRegularExpression('/<td class="positive">\s*2\s*<\/td>/', $output);
         $this->assertMatchesRegularExpression('/<td class="negative">\s*1\s*<\/td>/', $output);
         $this->assertStringContainsString('name="csrf_token" value="'.htmlspecialchars($token, ENT_QUOTES).'"', $output);
-        $this->assertStringContainsString('<button class="view-trades">', $output);
+        $this->assertStringContainsString('<a class="view-trades" href="trades_view.php?pair_id=1&amp;date=2024-01-02">Trades</a>', $output);
     }
 
     public function testAddingPairCapitalizesName(): void


### PR DESCRIPTION
## Summary
- Add link to view trades for each pair with appropriate href
- Update JS to populate trade links with the selected date
- Adjust index page test to expect an anchor link for trades

## Testing
- `composer install`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f5b2dce48326877cf3c9f100f92b