### PR TITLE
Add trade removal button to trade view

### DIFF
--- a/assets/js/trades_view.js
+++ b/assets/js/trades_view.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const csrfTokenInput = document.getElementById('csrf_token');
+    const csrfToken = csrfTokenInput ? csrfTokenInput.value : '';
+
+    document.querySelectorAll('button.remove-trade').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            const tr = btn.closest('tr');
+            const id = btn.getAttribute('data-id');
+            fetch('trades.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'remove', id, csrf_token: csrfToken }),
+                credentials: 'same-origin'
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    tr.remove();
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            })
+            .catch(err => {
+                console.error('Fetch error:', err);
+                alert('An error occurred while communicating with the server. Please try again later.');
+            });
+        });
+    });
+});

--- a/tests/TradesApiTest.php
+++ b/tests/TradesApiTest.php
@@ -91,4 +91,27 @@ class TradesApiTest extends TestCase
         $this->assertContains('positive', $types);
         $this->assertContains('negative', $types);
     }
+
+    public function testRemoveTrade(): void
+    {
+        $payload = [
+            'action' => 'add',
+            'pair_id' => 1,
+            'type' => 'positive',
+            'date' => '2024-01-01',
+            'csrf_token' => $this->csrfToken,
+        ];
+        handle_trades($payload);
+        $id = (int)$this->pdo->query('SELECT id FROM trades LIMIT 1')->fetchColumn();
+
+        $response = handle_trades([
+            'action' => 'remove',
+            'id' => $id,
+            'csrf_token' => $this->csrfToken,
+        ]);
+
+        $this->assertTrue($response['success']);
+        $count = (int)$this->pdo->query('SELECT COUNT(*) FROM trades')->fetchColumn();
+        $this->assertSame(0, $count);
+    }
 }

--- a/trades_view.php
+++ b/trades_view.php
@@ -8,6 +8,7 @@ $error_message = null;
 $pair_name = '';
 $pair_id = isset($_GET['pair_id']) ? (int)$_GET['pair_id'] : 0;
 $date = $_GET['date'] ?? date('Y-m-d');
+$csrf_token = get_csrf_token();
 
 try {
     $pdo = get_db();
@@ -27,10 +28,10 @@ if (!$error_message) {
     try {
         $driver = DB_DSN ? explode(':', DB_DSN, 2)[0] : 'mysql';
         if ($driver === 'sqlite') {
-            $sql = "SELECT date, type FROM trades WHERE pair_id = ? " .
+            $sql = "SELECT id, date, type FROM trades WHERE pair_id = ? " .
                 "AND date BETWEEN date(?, '-13 day') AND ? ORDER BY date DESC, id DESC";
         } else {
-            $sql = "SELECT date, type FROM trades WHERE pair_id = ? " .
+            $sql = "SELECT id, date, type FROM trades WHERE pair_id = ? " .
                 "AND date BETWEEN DATE_SUB(?, INTERVAL 13 DAY) AND ? ORDER BY date DESC, id DESC";
         }
         $stmt = $pdo->prepare($sql);
@@ -51,6 +52,7 @@ if (!$error_message) {
         body { font-family: sans-serif; margin: 2em; }
         table { border-collapse: collapse; width: 100%; }
         th, td { padding: 0.5em 1em; border: 1px solid #ccc; }
+        button.remove-trade { color: #fff; background: #f44336; border: none; padding: 0.3em 0.7em; cursor: pointer; }
     </style>
 </head>
 <body>
@@ -62,18 +64,21 @@ if (!$error_message) {
     <?php else: ?>
         <table>
             <thead>
-                <tr><th>Date</th><th>Type</th></tr>
+                <tr><th>Date</th><th>Type</th><th>Action</th></tr>
             </thead>
             <tbody>
                 <?php foreach ($trades as $t): ?>
-                <tr>
+                <tr data-trade-id="<?= (int)$t['id'] ?>">
                     <td><?= htmlspecialchars($t['date']) ?></td>
                     <td><?= htmlspecialchars($t['type']) ?></td>
+                    <td><button class="remove-trade" data-id="<?= (int)$t['id'] ?>">Remove</button></td>
                 </tr>
                 <?php endforeach ?>
             </tbody>
         </table>
+        <input type="hidden" id="csrf_token" value="<?= htmlspecialchars($csrf_token) ?>">
     <?php endif; ?>
     <p><a href="index.php?date=<?= htmlspecialchars($date) ?>">Back to main page</a></p>
+    <script src="assets/js/trades_view.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend trade API to include ids and support removing trades
- show remove button for each trade entry
- add browser script and tests for trade deletion

## Testing
- `composer install`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7f79f088326b6fc9f9d91c3dd32