### PR TITLE
Color trade cells according to count

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -2,6 +2,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const csrfInput = document.querySelector('#addPairForm input[name="csrf_token"]');
     const csrfToken = csrfInput ? csrfInput.value : '';
 
+    const updateCellColor = (td) => {
+        const value = parseInt(td.textContent, 10) || 0;
+        const percent = Math.min(value, 10) * 10;
+        const color = td.classList.contains('positive')
+            ? 'rgba(76, 175, 80, 0.5)'
+            : 'rgba(244, 67, 54, 0.5)';
+        td.style.background = percent === 0
+            ? '#fff'
+            : `linear-gradient(to right, ${color} ${percent}%, #fff ${percent}%)`;
+    };
+
+    document.querySelectorAll('td.positive, td.negative').forEach(updateCellColor);
+
     document.querySelectorAll('button.plus, button.minus').forEach(btn => {
         btn.addEventListener('click', e => {
             e.preventDefault();
@@ -11,14 +24,16 @@ document.addEventListener('DOMContentLoaded', () => {
             const date = document.getElementById('date').value;
             fetch('trades.php', {
                 method: 'POST',
-                headers: {'Content-Type': 'application/json'},
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'add', pair_id, type, date, csrf_token: csrfToken }),
                 credentials: 'same-origin'
             })
             .then(r => r.json())
             .then(data => {
                 if (data.success) {
-                    tr.querySelector('.' + type).textContent = data.count;
+                    const cell = tr.querySelector('.' + type);
+                    cell.textContent = data.count;
+                    updateCellColor(cell);
                 } else {
                     alert('Error: ' + data.error);
                 }


### PR DESCRIPTION
## Summary
- Shade positive and negative trade cells based on their counts with 10% increments up to 10
- Recolor cells dynamically when trade counts change

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1fb65664c8326a2d434552f2debea