### PR TITLE
Ensure trades script initializes regardless of load timing

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+const init = () => {
     const csrfInput = document.querySelector('#addPairForm input[name="csrf_token"]');
     const csrfToken = csrfInput ? csrfInput.value : '';
 
@@ -55,4 +55,11 @@ document.addEventListener('DOMContentLoaded', () => {
             link.href = `trades_view.php?pair_id=${encodeURIComponent(pair_id)}&date=${encodeURIComponent(date)}`;
         });
     });
-});
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}
+


### PR DESCRIPTION
## Summary
- wrap trade table script in `init` function
- trigger initialization on DOMContentLoaded or immediately based on `document.readyState`

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b205e9a410832685ff58325fab73dc