### PR TITLE
Display trades for selected date on main page

### DIFF
--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -55,6 +55,32 @@ const init = () => {
             link.href = `trades_view.php?pair_id=${encodeURIComponent(pair_id)}&date=${encodeURIComponent(date)}`;
         });
     });
+
+    document.querySelectorAll('#tradesTable .remove-trade').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            const tr = btn.closest('tr');
+            const id = btn.getAttribute('data-id');
+            fetch('trades.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'remove', id, csrf_token: csrfToken }),
+                credentials: 'same-origin'
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    tr.remove();
+                } else {
+                    alert('Error: ' + data.error);
+                }
+            })
+            .catch(err => {
+                console.error('Fetch error:', err);
+                alert('An error occurred while communicating with the server. Please try again later.');
+            });
+        });
+    });
 };
 
 if (document.readyState === 'loading') {

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -42,6 +42,10 @@ class IndexPageTest extends TestCase
         $this->assertMatchesRegularExpression('/<td class="negative">\s*1\s*<\/td>/', $output);
         $this->assertStringContainsString('name="csrf_token" value="'.htmlspecialchars($token, ENT_QUOTES).'"', $output);
         $this->assertStringContainsString('<a class="view-trades" href="trades_view.php?pair_id=1&amp;date=2024-01-02">Trades</a>', $output);
+        $this->assertStringContainsString('Trades on 2024-01-02', $output);
+        $this->assertStringContainsString('<td>BTCUSD</td>', $output);
+        $this->assertStringContainsString('<td>positive</td>', $output);
+        $this->assertStringContainsString('class="remove-trade"', $output);
     }
 
     public function testAddingPairCapitalizesName(): void


### PR DESCRIPTION
## Summary
- Load trades for the chosen date and render them on the index page with remove controls.
- Add client-side removal logic for trades.
- Extend index page tests to verify new trades table.

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68b2cd99a368832697b38a4cc6a4c2f3